### PR TITLE
Refactor core design:

### DIFF
--- a/src/clopengl/core.clj
+++ b/src/clopengl/core.clj
@@ -19,12 +19,12 @@
 
   (def window (window/create {:width 1280 :height 960 :title "My Game"}))
 
-  (let [programs {:default (:id (interface/data->opengl! new-prog/default-prog))
-                  :light-source (:id (interface/data->opengl! new-prog/light-source))}]
+  (let [programs {:default (:program/id (interface/data->opengl! :glsl/program new-prog/default-prog))
+                  :light-source (:program/id (interface/data->opengl! :glsl/program new-prog/light-source))}]
     (swap! (state/get-atom) assoc-in [:engine :shader-programs] programs))
 
   ;; Load shapes datas to GC and store render functions
-  ;; (def pandaki (vertices/setup (ply/parse-ply "pandaki2.ply") 10 (state/shader-program :default) (rand-positions 1 0.0 10.0)))
+  (def pandaki (vertices/setup (ply/parse-ply "pandaki2.ply") 10 (state/shader-program :default) (rand-positions 1 0.0 10.0)))
   ;;(def triangles (vertices/setup (shape/triangle true) 200 (state/shader-program :default) (rand-positions 1 0.0 10.0)))
   ;;(def cubes (vertices/setup (shape/cube true) 100 (state/shader-program :default) (rand-positions 1 0.0 10.0)))
   ;;(def ground (vertices/setup (shape/rectangle2D 100 75 :vertical) 1 (state/shader-program :default) (rand-positions 1 0.0 10.0)))

--- a/src/clopengl/engine/opengl/window.clj
+++ b/src/clopengl/engine/opengl/window.clj
@@ -6,9 +6,8 @@
             [clopengl.engine.utilities.transformations :as transformation]
             [clopengl.engine.state.global :as state]
 	          [clopengl.engine.glfw.controls.mouse :as mouse]
-            [clopengl.opengl.data.3D-transformations :as t3d]
             [clopengl.opengl.abstract.interface :as interface]
-            [clopengl.opengl.matrices :as _])
+            [clopengl.opengl.matrices :as mx])
   (:import (org.lwjgl BufferUtils)
            (org.lwjgl.glfw GLFW GLFWKeyCallback GLFWErrorCallback)
            (org.lwjgl.system MemoryUtil)
@@ -78,15 +77,20 @@
   "Draw everything needed in the GLFW window. to-render-functions is a vector of functions that contains OpenGL instructions to draw shapes from corresponding VAO"
   (let [cam (buffer/create-float-buffer (transformation/make "look-at" [(state/get-data :camera)]))
         cam-position (buffer/create-float-buffer (state/cam :front))
-        pos-trans-data (-> (t3d/transform-matrix)
-                           (t3d/+rotate :x (* 200.0 (GLFW/glfwGetTime)))
-                           (t3d/+rotate :z (* 200.0 (GLFW/glfwGetTime)))
-                           (t3d/+scale (+ 4.0 (Math/sin (GLFW/glfwGetTime))))
-                           (t3d/+translate :x (* 2.0 (Math/sin (GLFW/glfwGetTime))))
-                           (t3d/+translate :y (* 2.0 (Math/sin (GLFW/glfwGetTime))))
-                           (t3d/+translate :z (* 2.0 (Math/sin (GLFW/glfwGetTime)))))
+        pos-trans-data (-> mx/build-3d-transform
+                           ;; (mx/+rotate :y (* 100.0 (GLFW/glfwGetTime)))
+                           ;; (mx/+rotate :z (* 100.0 (GLFW/glfwGetTime)))
+                           (mx/+rotate :x (* 100.0 (GLFW/glfwGetTime)))
+                           ;; (mx/+scale :x (Math/abs (Math/sin (GLFW/glfwGetTime))))
+                           ;; (mx/+scale :y (+ 1.0 (Math/abs (Math/sin (GLFW/glfwGetTime)))))
+                           ;; (mx/+scale :z (+ 1.0 (Math/abs (Math/sin (GLFW/glfwGetTime)))))
+                           ;; (mx/+scale :x (+ 1.0 (Math/abs (Math/sin (GLFW/glfwGetTime)))))
+                           ;; (mx/+translate :x (* 5.0 (Math/sin (GLFW/glfwGetTime))))
+                           ;; (mx/+translate :y (* 3.0 (Math/sin (GLFW/glfwGetTime))))
+                           ;; (mx/+translate :z (* 8.0 (Math/sin (GLFW/glfwGetTime))))
+                           )
 
-        pos-trans-buffer (:buffer (interface/data->opengl! pos-trans-data))]
+        pos-trans-buffer (:buffer (interface/data->opengl! :3d/tranform pos-trans-data))]
 
   (GL11/glClearColor 0.0 0.0 0.8 0.5)
   (GL11/glClear (bit-or GL11/GL_COLOR_BUFFER_BIT GL11/GL_DEPTH_BUFFER_BIT))

--- a/src/clopengl/opengl/abstract/interface.clj
+++ b/src/clopengl/opengl/abstract/interface.clj
@@ -1,11 +1,11 @@
 (ns clopengl.opengl.abstract.interface
-  "Interface definition for interpreting data.")
+  "Interface definition for interpreting data."
+  (:require [clojure.spec.alpha :as s]))
 
 (defmulti data->opengl!
-  (fn [data & opts]
-    (:type data)))
+  (fn [t data & _]
+    (if (s/valid? t data)
+      t
+      :invalid)))
 
-;; Would it be usefull?
-;; (defmulti data->record
-;;   (fn [data]
-;;     (:type data)))
+(defmethod data->opengl! :invalid [t h & opts] (clojure.pprint/pprint (s/explain-data t h)))

--- a/src/clopengl/opengl/data/3D_transformations.clj
+++ b/src/clopengl/opengl/data/3D_transformations.clj
@@ -1,29 +1,51 @@
 (ns clopengl.opengl.data.3D-transformations
   ""
-  )
+  (:require [clojure.spec.alpha :as s]
+            [clopengl.opengl.util.basic-specs :as _]))
 
-(defn transform-matrix
-  "Create a transform"
-  []
-  {:type :transform/matrix
-   :rotation {:x 1.0 :y 1.0 :z 1.0}
-   :translation {:x 0 :y 0 :z 0}
-   :scale 1.0})
+(s/def :3d/tranform (s/keys :req [(or :matrix/rotation :matrix/translation :matrix/scalation)]
+                            :opt [:matrix/rotation :matrix/translation :matrix/scalation]))
+(defonce blank-3d-transform {
+  :matrix/rotation nil
+  :matrix/translation nil
+  :matrix/scalation nil
+})
 
-(defn +rotate
-  ([axis angle]
-   {axis angle})
-  ([motion axis angle]
-   (let [r (+rotate axis angle)]
-     (assoc motion :rotation (merge (:rotation motion) r)))))
 
-(defn +translate
-  ([axis value]
-   {axis value})
-  ([motion axis value]
-   (let [t (+translate axis value)]
-     (assoc motion :translation (merge (:translation motion) t)))))
+(s/def :matrix/rotation (s/nilable (s/keys :req [(or :rotate/x :rotate/y :rotate/z)]
+                                   :opt [:rotate/x :rotate/y :rotate/z])))
+(defonce blank-rotation {
+  :rotate/x 0.0
+  :rotate/y 0.0
+  :rotate/z 0.0
+})
 
-(defn +scale
-  ([motion value]
-   (assoc motion :scale value)))
+
+(s/def :matrix/translation (s/nilable (s/keys :req [(or :translate/x :translate/y :translate/z)]
+                                              :opt [:translate/x :translate/y :translate/z])))
+(defonce blank-translation {
+  :translate/x 0.0
+  :translate/y 0.0
+  :translate/z 0.0
+})
+
+
+(s/def :matrix/scalation (s/nilable (s/keys :req [(or :scale/x :scale/y :scale/z)]
+                                            :opt [:scale/x :scale/y :scale/z])))
+(defonce blank-scalation {
+  :scale/x nil
+  :scale/y nil
+  :scale/z nil
+})
+
+
+
+(s/def :rotate/x :clopengl/coord)
+(s/def :rotate/y :clopengl/coord)
+(s/def :rotate/z :clopengl/coord)
+(s/def :translate/x :clopengl/coord)
+(s/def :translate/y :clopengl/coord)
+(s/def :translate/z :clopengl/coord)
+(s/def :scale/x :clopengl/coord)
+(s/def :scale/y :clopengl/coord)
+(s/def :scale/z :clopengl/coord)

--- a/src/clopengl/opengl/matrices.clj
+++ b/src/clopengl/opengl/matrices.clj
@@ -4,19 +4,61 @@
   (:import (org.joml Matrix4f)
            (org.lwjgl BufferUtils)))
 
-(defmethod interface/data->opengl! :transform/matrix
-  [h & _]
+
+(defonce build-3d-transform data/blank-3d-transform)
+
+(defn +rotate
+  ([axis angle]
+   (let [k (keyword "rotate" (name axis))]
+     (-> data/blank-rotation
+       (update k + angle))))
+  ([t3d axis angle]
+   (let [r  (+rotate axis angle)
+         rr (merge-with + (:matrix/rotation t3d) r)]
+     (assoc t3d :matrix/rotation rr))))
+
+(defn +translate
+  ([axis value]
+   (let [k (keyword "translate" (name axis))]
+     (-> data/blank-translation
+       (update k + value))))
+  ([t3d axis value]
+   (let [t  (+translate axis value)
+         tt (merge-with + (:matrix/translation t3d) t)]
+     (assoc t3d :matrix/translation tt))))
+
+(defn +scale
+  ([axis value]
+   (let [k (keyword "scale" (name axis))]
+     (-> data/blank-scalation
+       (assoc k value))))
+  ([t3d axis value]
+   (let [k  (keyword "scale" (name axis))
+         ms (:matrix/scalation t3d)
+         ss (cond
+              (nil? ms) (+scale axis value)
+              (nil? (k ms)) (assoc ms k value)
+              :else (update ms k + value))]
+     (assoc t3d :matrix/scalation ss))))
+
+
+
+
+(defmethod interface/data->opengl! :3d/tranform
+  [_ h & _]
   (let [buffer (BufferUtils/createFloatBuffer 16)
-        rx (Math/toRadians (get-in h [:rotation :x]))
-        ry (Math/toRadians (get-in h [:rotation :y]))
-        rz (Math/toRadians (get-in h [:rotation :z]))
-        tx (get-in h [:translation :x])
-        ty (get-in h [:translation :y])
-        tz (get-in h [:translation :z])
-        sc (:scale h)]
+        rx (Math/toRadians (or (get-in h [:matrix/rotation :rotate/x]) 0.0))
+        ry (Math/toRadians (or (get-in h [:matrix/rotation :rotate/y]) 0.0))
+        rz (Math/toRadians (or (get-in h [:matrix/rotation :rotate/z]) 0.0))
+        tx (or (get-in h [:matrix/translation :translate/x]) 0.0)
+        ty (or (get-in h [:matrix/translation :translate/y]) 0.0)
+        tz (or (get-in h [:matrix/translation :translate/z]) 0.0)
+        sx (or (get-in h [:matrix/scalation :scale/x]) 1.0)
+        sy (or (get-in h [:matrix/scalation :scale/y]) 1.0)
+        sz (or (get-in h [:matrix/scalation :scale/z]) 1.0)]
     (-> (Matrix4f.)
       (.translate tx ty tz)
       (.rotateXYZ rx ry rz)
-      (.scale sc sc sc)
+      (.scale sx sy sz)
       (.get buffer))
   (assoc h :buffer buffer)))

--- a/src/clopengl/opengl/program.clj
+++ b/src/clopengl/opengl/program.clj
@@ -1,47 +1,45 @@
 (ns clopengl.opengl.program
   (:import (org.lwjgl.opengl GL20))
-  (:require [clopengl.opengl.data.glsl-objects :refer :all]
+  (:require [clopengl.opengl.data.glsl-objects :as data]
             [clopengl.opengl.abstract.interface :as interface]
             [clojure.java.io :as io]))
 
 
-;;{
-;;  :id nil,
-;;  :type :program,
-;;  :uniforms {
-;;    "project" {
-;;      :name "project",
-;;      :type "Matrix4f",
-;;      :value [[0 0 0 0] [0 0 0 0] [0 0 0 0] [0 0 0 0]],
-;;      :location nil
-;;    }
-;;  },
-;;  :shaders [
-;;    {:path "path.vert", :type :shader, :stage "GL20/GL_VERTEX_SHADER"}
-;;    {:path "path.frag", :type :shader, :stage "GL20/GL_FRAGMENT_SHADER"}
-;;  ]
-;;}
 
-(def default-prog
-  (-> (program)
-      (+shader  "shaders/vertices/default.vert" GL20/GL_VERTEX_SHADER)
-      (+shader  "shaders/fragments/lightnings/default.frag" GL20/GL_FRAGMENT_SHADER)
-      (+uniform "view" "mat4")
-      (+uniform "projection" "mat4")
-      (+uniform "positionTransformation" "mat4")))
+(defonce build-program data/blank-program)
 
-(def light-source
-  (-> (program)
-      (+shader  "shaders/vertices/light-source.vert" GL20/GL_VERTEX_SHADER)
-      (+shader  "shaders/fragments/default.frag" GL20/GL_FRAGMENT_SHADER)
-      (+uniform "view" "mat4")
-      (+uniform "projection" "mat4")
-      (+uniform "positionTransformation" "mat4")))
+(defn +shader
+  "Creates a shader datastructure and place it in the provided program (if any)."
+  ([path stage]
+    (-> data/blank-shader
+        (assoc :shader/path path)
+        (assoc :shader/stage stage)))
+  ([program path stage]
+   (let [shader (+shader path stage)]
+     (update program :program/shaders conj shader))))
 
-(defmethod interface/data->opengl! :program
-  [h & _]
+(defn +uniform
+  "Creates a uniform datastructure with or without value and store it in the provided programe (if any)."
+  ([uname vtype]
+   (-> data/blank-uniform
+       (assoc :uniform/name uname)
+       (assoc :uniform/type vtype)))
+  ([program uname vtype]
+   (let [uniform (+uniform uname vtype)]
+     (assoc-in program [:program/uniforms uname] uniform))))
+
+(defn uniform=
+  "Set program's uniform `uname` value"
+  ([program uname value]
+   (assoc-in program [:program/uniforms uname :value] value)))
+
+
+
+
+(defmethod interface/data->opengl! :glsl/program
+  [_ h & _]
   (let [program-id (GL20/glCreateProgram)
-        shader-ids (map interface/data->opengl! (:shaders h))
+        shader-ids (map #(interface/data->opengl! :glsl/shader %) (:program/shaders h))
                    ;; Attach compiled shaders code to program
         _          (doseq [sid shader-ids] (GL20/glAttachShader program-id sid))
                    ;; Link program
@@ -53,20 +51,20 @@
                                             (GL20/glGetProgramInfoLog program-id 1024))))))
                    ;; Get uniforms locations
         uniforms   (into {} (map
-                              (fn [[k v]] [k (interface/data->opengl! v program-id)])
-                              (:uniforms h)))]
+                              (fn [[k v]] [k (interface/data->opengl! :glsl/uniform v program-id)])
+                              (:program/uniforms h)))]
     ;; Delete shaders
     (doseq [sid shader-ids]
       (GL20/glDeleteShader sid))
 
     (-> h
-        (assoc :id program-id)
-        (assoc :uniforms uniforms))))
+        (assoc :program/id program-id)
+        (assoc :program/uniforms uniforms))))
 
-(defmethod interface/data->opengl! :shader
-  [h & _]
-  (let [stage (:stage h)
-        path (:path h)
+(defmethod interface/data->opengl! :glsl/shader
+  [_ h & _]
+  (let [stage (:shader/stage h)
+        path (:shader/path h)
         id    (GL20/glCreateShader stage)
         code  (-> path (io/resource) (io/file) (slurp))]
     (when (= 0 id)
@@ -77,9 +75,29 @@
       (throw (Exception. (str "Error compiling shader: " (GL20/glGetShaderInfoLog id 1024) " in " path))))
     id))
 
-(defmethod interface/data->opengl! :uniform
-  [h & opts]
-  (let [uname      (:name h)
+(defmethod interface/data->opengl! :glsl/uniform
+  [_ h & opts]
+  (let [uname      (:uniform/name h)
         program-id (first opts)
         location   (GL20/glGetUniformLocation ^Long program-id ^String uname)]
-    (assoc h :location location)))
+    (assoc h :uniform/location location)))
+
+
+
+
+;; DSL usage examples
+(def default-prog
+  (-> build-program
+      (+shader  "shaders/vertices/default.vert" GL20/GL_VERTEX_SHADER)
+      (+shader  "shaders/fragments/lightnings/default.frag" GL20/GL_FRAGMENT_SHADER)
+      (+uniform "view" "mat4")
+      (+uniform "projection" "mat4")
+      (+uniform "positionTransformation" "mat4")))
+
+(def light-source
+  (-> build-program
+      (+shader  "shaders/vertices/light-source.vert" GL20/GL_VERTEX_SHADER)
+      (+shader  "shaders/fragments/default.frag" GL20/GL_FRAGMENT_SHADER)
+      (+uniform "view" "mat4")
+      (+uniform "projection" "mat4")
+      (+uniform "positionTransformation" "mat4")))

--- a/src/clopengl/opengl/util/basic_specs.clj
+++ b/src/clopengl/opengl/util/basic_specs.clj
@@ -1,0 +1,6 @@
+(ns clopengl.opengl.util.basic-specs
+  (:require [clojure.spec.alpha :as s]))
+
+(s/def :clopengl/id int?)
+(s/def :clopengl/path string?)
+(s/def :clopengl/coord (s/nilable float?))


### PR DESCRIPTION
- Domain data structures are now backed by specs
- DSL, while still usefull, is no more responsible for ensuring data-structures consistency (specs are)
- All domain data structure map keys are namespaced to permit more openness (things can be mixed up together a bit)
- data->opengl! multi method now dispatch on a spec'ed keywords, ensuring spec validity